### PR TITLE
[Experimental] Add Chat History Feature

### DIFF
--- a/web/src/app/components/search.tsx
+++ b/web/src/app/components/search.tsx
@@ -1,20 +1,34 @@
 "use client";
 import { getSearchUrl } from "@/app/utils/get-search-url";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, ArrowUp } from "lucide-react";
 import { nanoid } from "nanoid";
 import { useRouter } from "next/navigation";
 import React, { FC, useState } from "react";
+import { useSearchParams } from "next/navigation";
 
-export const Search: FC = () => {
+interface SearchProps {
+  useContinueButton?: boolean; // true: 使用“继续对话”按钮; false: 使用“新的搜索”按钮
+}
+export const Search: FC<SearchProps> = ({ useContinueButton = false }) => {
   const [value, setValue] = useState("");
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const old_rid = decodeURIComponent(searchParams.get("rid") || "");
+  const handleNewSearch = () => {
+    // 可以在这里重置任何需要的状态，以准备一个新的搜索
+    if (value) {
+      setValue(""); // 清空搜索框
+      router.push(getSearchUrl(encodeURIComponent(value), nanoid()));
+    }
+  };
   return (
     <form
       onSubmit={(e) => {
         e.preventDefault();
         if (value) {
           setValue("");
-          router.push(getSearchUrl(encodeURIComponent(value), nanoid()));
+          const rid = useContinueButton ? old_rid : nanoid();
+          router.push(getSearchUrl(encodeURIComponent(value), rid));
         }
       }}
     >
@@ -34,7 +48,7 @@ export const Search: FC = () => {
           type="submit"
           className="w-auto py-1 px-2 bg-black border-black text-white fill-white active:scale-95 border overflow-hidden relative rounded-xl"
         >
-          <ArrowRight size={16} />
+          {useContinueButton ? <ArrowUp size={16} /> : <ArrowRight size={16} />}
         </button>
       </label>
     </form>

--- a/web/src/app/search/page.tsx
+++ b/web/src/app/search/page.tsx
@@ -18,7 +18,7 @@ export default function SearchPage() {
         <div className="h-80 pointer-events-none w-full rounded-b-2xl backdrop-filter absolute bottom-0 bg-gradient-to-b from-transparent to-white [mask-image:linear-gradient(to_top,white,transparent)]"></div>
         <div className="absolute z-10 flex items-center justify-center bottom-6 px-4 md:px-8 w-full">
           <div className="w-full">
-            <Search></Search>
+            <Search useContinueButton={true}></Search>
           </div>
         </div>
       </div>


### PR DESCRIPTION
添加了一个聊天历史功能。该功能可通过 `CHAT_HISTORY` 环境变量开启或关闭，允许用户持续使用当前搜索会话。

说明：
- **环境变量控制**：`CHAT_HISTORY` 用于控制聊天历史功能的开启状态。
- **存储**：使用 `SqliteDict` 对聊天记录进行存储。
- **对话识别**：通过请求中的 `rid` 参数识别是否为同一对话，相同 `rid` 视为同一对话。
- **对话长度**：代码中的`MAX_HISTORY_LEN` 变量用于控制聊天记录的最大长度，默认10。
- **对话开始逻辑**：首页或相关搜索触发的搜索被视为新对话，而在搜索页面的搜索框输入视为同一聊天。搜索框显示↑箭头为当前对话、→箭头为新开会话。
- **搜索API请求**：启用聊天历史后，仅第一个搜索触发API请求，后续对话基于第一次搜索结果。

修改原代码内容：
- 调整了通过 `rid` 缓存的数据格式，以适应聊天记录存储，旧数据会重新发起搜索。
- 修改获取会话缓存部分的代码，此处修改较多。

实现：
- 根据rid存储聊天记录，同一个rid请求先读取旧的记录。
- 将上一步的聊天记录，直接插入原OpenAI请求 messages 中，作为历史数据发送。

风险：
- 完成了基本测试：开启关闭、旧数据测试等，但是没有覆盖的测试仍然较多。

缺陷：
- 仅实现了基本历史记录存储、插入功能，prompt 等细节没有优化。
- 聊天记录过长可能导致 token 超过最大限制，代码没有对聊天的长度进行限制。


Added a chat history feature. This feature can be toggled on or off with the `CHAT_HISTORY` environment variable, allowing users to continue using the current search session.

Details:
- **Environment Variable Control**: `CHAT_HISTORY` is used to control the activation state of the chat history feature.
- **Storage**: `SqliteDict` is used for storing chat records.
- **Conversation Identification**: Identifies whether it is the same conversation through the `rid` parameter in the request. Identical `rid`s are considered the same conversation.
- **Conversation Length**: The `MAX_HISTORY_LEN` variable in the code controls the maximum length of chat records, with a default of 10.
- **Conversation Start Logic**: Searches triggered from the homepage or related searches are considered new conversations, while inputs in the search box on the search page are considered the same chat. In the UI, an upwards arrow (↑) indicates the current conversation, and a rightwards arrow (→) indicates starting a new session.
- **Search API Request**: With chat history enabled, only the first search triggers an API request. Subsequent conversations are based on the results of the first search.

Modifications to the original code:
- Adjusted the data format for caching with `rid` to accommodate chat record storage. Old data will initiate a new search.
- Modified the code for retrieving session cache, with substantial changes.

Implementation:
- Stores chat records based on `rid`, reading old records for the same `rid` requests first.
- Inserts the previous step's chat records directly into the original OpenAI request messages as historical data to be sent.

Risks:
- Basic testing completed: toggling on/off, old data testing, etc., but there are still many untested areas.

Shortcomings:
- Only the history recording feature was implemented, details such as prompt optimization were not addressed.
- Chat records being too long might lead to exceeding the maximum token limit for requests. This PR did not impose limits on the length of the chat.


